### PR TITLE
Fix release workflow to use renamed project path

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,3 +41,4 @@ jobs:
         
       - name: Check coverage
         run: go tool cover -func=coverage.out
+        

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -32,13 +32,12 @@ jobs:
             gofmt -l .
             exit 1
           fi
-          
+
       - name: Run linters
         run: golangci-lint run
-          
+
       - name: Test with coverage
         run: go test ./... -coverprofile=coverage.out
-        
+
       - name: Check coverage
         run: go tool cover -func=coverage.out
-        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.24'
-          
+
       - name: Test
         run: go test ./...
 
@@ -23,34 +23,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.24'
-          
+
       - name: Build for Linux
         run: |
           go build -v ./...
           go build -o gollm-linux cmd/gollm/main.go
-          
+
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
         with:
           name: gollm-linux
           path: gollm-linux
-  
+
   build-apple:
     needs: test
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.24'
-          
+
       - name: Build for Apple Silicon
         env:
           GOOS: darwin
@@ -58,10 +58,9 @@ jobs:
         run: |
           go build -v ./...
           go build -o gollm-darwin-arm64 cmd/gollm/main.go
-          
+
       - name: Upload Apple Silicon artifact
         uses: actions/upload-artifact@v4
         with:
           name: gollm-darwin-arm64
           path: gollm-darwin-arm64
-          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: gollm-darwin-arm64
           path: gollm-darwin-arm64
+          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,13 @@ jobs:
       - name: Build for Linux
         run: |
           go build -v ./...
-          go build -o go-llm-linux cmd/go-llm/main.go
+          go build -o gollm-linux cmd/gollm/main.go
           
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
         with:
-          name: go-llm-linux
-          path: go-llm-linux
+          name: gollm-linux
+          path: gollm-linux
   
   build-apple:
     needs: test
@@ -57,10 +57,10 @@ jobs:
           GOARCH: arm64
         run: |
           go build -v ./...
-          go build -o go-llm-darwin-arm64 cmd/go-llm/main.go
+          go build -o gollm-darwin-arm64 cmd/gollm/main.go
           
       - name: Upload Apple Silicon artifact
         uses: actions/upload-artifact@v4
         with:
-          name: go-llm-darwin-arm64
-          path: go-llm-darwin-arm64
+          name: gollm-darwin-arm64
+          path: gollm-darwin-arm64


### PR DESCRIPTION
Updated references from go-llm to gollm in the release.yml file to match the current project structure.

🤖 Generated with [Claude Code](https://claude.ai/code)